### PR TITLE
Record consented completed games for training

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ dist/
 coverage/
 playwright-report/
 test-results/
+.wrangler/
+.dev.vars*
+.env*
+!.env.example
+!.dev.vars.example

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Building a robot that can play bridge, and training it using ML
 The TanStack Start web app lives in `web/`. It lets 0-4 human players play a
 bridge deal with bots filling the remaining seats. Practice mode reveals all
 hands in the UI, while bot decision code still receives only the information a
-bot seat is allowed to know.
+bot seat is allowed to know. The table can also opt in to sharing completed
+anonymous boards for training.
 
 ```bash
 pnpm --dir web install
@@ -39,8 +40,8 @@ pnpm --dir web exec playwright install chromium
 Cloudflare web deployment:
 
 ```bash
-pnpm --dir web cf:deploy
-pnpm --dir web cf:dry-run
+VITE_BRIDGEBOT_API_URL=https://bridgebot-api.<your-account>.workers.dev pnpm --dir web cf:dry-run
+VITE_BRIDGEBOT_API_URL=https://bridgebot-api.<your-account>.workers.dev pnpm --dir web cf:deploy
 ```
 
 ## Cloudflare Python Worker backend
@@ -61,6 +62,31 @@ Local backend contract tests are included in the root pytest suite:
 pytest
 ```
 
+Create the R2 buckets before deploying game recording:
+
+```bash
+pnpm --dir web exec wrangler r2 bucket create bridgebot-training-games
+pnpm --dir web exec wrangler r2 bucket create bridgebot-training-games-preview
+```
+
+Backend endpoints:
+
+- `GET /health`
+- `POST /api/bot/action` for limited-information bot decisions
+- `POST /api/training/games` for consented completed-game records
+
+## Privacy and training records
+
+Game sharing is off by default in the web UI. When enabled, the app submits only
+completed or passed-out boards. The record includes board context, final hands,
+auction, tricks, score, seed, and seat controller types so it can be used for
+offline training and evaluation.
+
+The training endpoint rejects personal-data keys such as names, email
+addresses, account IDs, session IDs, visitor IDs, IP addresses, user agents,
+browser details, and device details. The in-app privacy policy is available at
+`/privacy`, with a documentation copy in `docs/source/privacy.rst`.
+
 ## Integration docs
 
 - `docs/source/web_app.rst` describes the web table, gameplay flow, and current
@@ -69,6 +95,8 @@ pytest
   external bridge services or physical-card tables without leaking hidden state.
 - `docs/source/cloudflare_deployment.rst` describes the Cloudflare web and
   Python Worker deployables.
+- `docs/source/privacy.rst` describes what optional training records include and
+  exclude.
 - `docs/specs/gameplay-web-app.md` is the implemented gameplay spec.
 - `docs/specs/limited-information-bot-adapter.md` is the privacy and adapter
   contract for outside tables.

--- a/docs/source/cloudflare_deployment.rst
+++ b/docs/source/cloudflare_deployment.rst
@@ -5,7 +5,8 @@ The project is split into two Cloudflare deployables:
 
 * ``web/``: the TanStack Start table, deployed as a Cloudflare Worker with
   Wrangler.
-* ``workers/backend/``: a Python Worker API for server-side bot decisions.
+* ``workers/backend/``: a Python Worker API for server-side bot decisions and
+  anonymous completed-game training records.
 
 The split keeps the UI runtime and Python AI/runtime experiments independent.
 It also reinforces the limited-information boundary: the backend API accepts a
@@ -21,8 +22,12 @@ Useful commands::
 
    pnpm --dir web dev
    pnpm --dir web build
-   pnpm --dir web cf:dry-run
-   pnpm --dir web cf:deploy
+   VITE_BRIDGEBOT_API_URL=https://bridgebot-api.<your-account>.workers.dev pnpm --dir web cf:dry-run
+   VITE_BRIDGEBOT_API_URL=https://bridgebot-api.<your-account>.workers.dev pnpm --dir web cf:deploy
+
+If ``VITE_BRIDGEBOT_API_URL`` is not set, the web app posts training records to
+same-origin ``/api/training/games``. Set it when the web and backend Workers use
+separate ``*.workers.dev`` hostnames.
 
 Python Worker backend
 ---------------------
@@ -33,7 +38,13 @@ The backend worker is intentionally small for now:
   object to pure Python request handling.
 * ``workers/backend/src/bridgebot_api.py`` implements the testable API contract.
 * ``workers/backend/wrangler.jsonc`` enables the ``python_workers``
-  compatibility flag.
+  compatibility flag and binds the ``TRAINING_GAMES`` R2 bucket used for
+  training records.
+
+Create the R2 buckets before deploying the backend::
+
+   pnpm --dir web exec wrangler r2 bucket create bridgebot-training-games
+   pnpm --dir web exec wrangler r2 bucket create bridgebot-training-games-preview
 
 Useful commands::
 
@@ -52,10 +63,21 @@ Backend API
    plus ``legalMoves.calls`` or ``legalMoves.cards`` for clients to render only
    legal choices.
 
+``POST /api/training/games``
+   Accepts an explicitly consented, anonymous, completed-game record for model
+   training. The Python Worker stores valid records in the ``TRAINING_GAMES``
+   R2 bucket when that binding is configured.
+
 Hidden-state keys such as ``hands``, ``allHands``, ``deal``, or per-seat hand
 names are rejected. This is deliberate: integrations with online bridge tables
 or physical-card capture should never send the backend more state than the bot
 seat is allowed to know.
+
+Training-game records are the exception to the hidden-state rule because they
+are sent only after a board is complete or passed out and include the full deal
+needed for offline model evaluation. The endpoint rejects personal-data keys
+such as names, email addresses, session IDs, visitor IDs, IP addresses, and user
+agents.
 
 Verification
 ------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,6 +13,7 @@ Welcome to bridgebot's documentation!
    web_app
    limited_information_bots
    cloudflare_deployment
+   privacy
    specs
 
 

--- a/docs/source/privacy.rst
+++ b/docs/source/privacy.rst
@@ -1,0 +1,44 @@
+Privacy Policy
+==============
+
+Effective June 16, 2026.
+
+Bridge Bot runs a local bridge table in the browser and can optionally share
+completed game records for bot training.
+
+Game Recording
+--------------
+
+Game sharing is off by default. If a player turns on Share games, the web app
+sends completed or passed-out boards to the backend. The backend accepts only
+records that include explicit training consent metadata.
+
+Data Stored
+-----------
+
+Training records may include:
+
+* board number, seed, dealer, vulnerability, and final phase;
+* seat controller types;
+* final hands, auction, contract, tricks, trick counts, and score;
+* the privacy policy version attached to the consented record.
+
+Training records do not include:
+
+* names, email addresses, account IDs, session IDs, or visitor IDs;
+* IP addresses, user agents, browser details, or device details;
+* chat messages or profile text, because the table has no chat or profile
+  fields.
+
+Use
+---
+
+Shared games may be used to compare bot policies, train future bridge models,
+test scoring and bidding behavior, and improve gameplay quality. Records are
+anonymous table data, not user profiles.
+
+Control
+-------
+
+Players can turn off Share games at any time to stop sending future boards.
+Boards already accepted by the backend may remain in the training dataset.

--- a/docs/source/web_app.rst
+++ b/docs/source/web_app.rst
@@ -24,6 +24,7 @@ The app supports:
   off.
 * Practice mode, which reveals all cards in the UI.
 * Duplicate-style board progression for dealer and vulnerability.
+* Optional anonymous sharing of completed boards for bot training.
 * Legal auction calls, passout detection, double/redouble legality, contract
   derivation, declarer and dummy assignment.
 * Legal play, including follow-suit enforcement, trump trick winners, trick
@@ -50,6 +51,10 @@ Primary Files
    Limited-information bot decision boundary used by local bots and external
    table adapters.
 
+``web/src/game/trainingRecord.ts``
+   Privacy-scoped serialization and submission of completed-game records for
+   training.
+
 ``web/src/game/*.test.ts`` and ``web/src/components/*.test.tsx``
    Regression tests for gameplay rules, UI behavior, and hidden-state privacy.
 
@@ -73,6 +78,8 @@ Known Limits
 
 * Bot bidding and card play are heuristic.
 * There is no persistence or multiplayer network transport.
+* Training sharing is opt-in and posts only terminal boards to the configured
+  backend endpoint.
 * External service adapters are not service-specific yet; they should be built
   on top of the limited-information observation contract described in
   :doc:`limited_information_bots`.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -3,7 +3,8 @@
 These files describe the implemented web bridge table and the integration
 contracts that should remain stable as the project grows.
 
-- `gameplay-web-app.md`: playable TanStack Start table requirements.
+- `gameplay-web-app.md`: playable TanStack Start table requirements, including
+  consented completed-game records for training.
 - `limited-information-bot-adapter.md`: privacy-preserving adapter contract for
   external bridge services and physical-card tables.
 - `cloudflare-deployment.md`: Cloudflare Worker deployment contract for the web

--- a/docs/specs/cloudflare-deployment.md
+++ b/docs/specs/cloudflare-deployment.md
@@ -7,6 +7,8 @@
   player work can evolve without coupling it to the web runtime.
 - Preserve the limited-information contract for external bridge services and
   physical-card integrations.
+- Store explicitly consented completed-game training records without collecting
+  player identifiers.
 
 ## Web Worker
 
@@ -24,9 +26,12 @@ Commands:
 ```bash
 pnpm --dir web dev
 pnpm --dir web build
-pnpm --dir web cf:dry-run
-pnpm --dir web cf:deploy
+VITE_BRIDGEBOT_API_URL=https://bridgebot-api.<your-account>.workers.dev pnpm --dir web cf:dry-run
+VITE_BRIDGEBOT_API_URL=https://bridgebot-api.<your-account>.workers.dev pnpm --dir web cf:deploy
 ```
+
+The API URL is optional only when `/api/*` routes to the backend on the same
+origin as the web Worker.
 
 ## Python Worker Backend
 
@@ -37,10 +42,14 @@ The backend worker lives in `workers/backend/` and deploys with pywrangler.
 - `workers/backend/src/entry.py` is the Cloudflare SDK entrypoint.
 - `workers/backend/src/bridgebot_api.py` contains the pure-Python request logic
   that local tests import directly.
+- `workers/backend/wrangler.jsonc` binds an R2 bucket named
+  `TRAINING_GAMES` for anonymous training-game records.
 
 Commands:
 
 ```bash
+pnpm --dir web exec wrangler r2 bucket create bridgebot-training-games
+pnpm --dir web exec wrangler r2 bucket create bridgebot-training-games-preview
 cd workers/backend
 uv run pywrangler dev
 uv run pywrangler deploy
@@ -69,6 +78,19 @@ The response must not echo `hand` or any complete deal state. Hidden-state keys
 such as `hands`, `allHands`, `deal`, and per-seat hand names must be rejected.
 Successful responses include `legalMoves.calls` during the auction or
 `legalMoves.cards` during play so clients can render only legal choices.
+
+`POST /api/training/games` accepts only records that:
+
+- use schema `bridgebot.training_game.v1`;
+- include `consent.shareForTraining: true`;
+- have final phase `complete` or `passedOut`;
+- include board context, final hands, auction, tricks, and score data;
+- omit personal-data keys including names, emails, account IDs, session IDs,
+  visitor IDs, IP addresses, user agents, browser details, and device details.
+
+Valid records are normalized, assigned a deterministic content hash ID, and
+stored under `training-games/v1/{recordId}.json` when the R2 binding is
+available.
 
 ## Verification
 

--- a/docs/specs/gameplay-web-app.md
+++ b/docs/specs/gameplay-web-app.md
@@ -68,6 +68,17 @@ behavior.
 - Completed contracts are scored for the declaring partnership and mirrored to
   the defending partnership.
 
+### Training Records
+
+- Game sharing is off by default.
+- When enabled, only completed or passed-out boards are submitted.
+- Submitted records must include consent metadata and the privacy policy
+  version.
+- Records may include the full final deal, auction, tricks, score, seed,
+  dealer, vulnerability, and seat controller types for offline training.
+- Records must not include player names, emails, account IDs, visitor IDs,
+  session IDs, IP addresses, user agents, browser details, or device details.
+
 ### Responsive UI
 
 - Desktop layout keeps seats, center trick area, and bidding controls in
@@ -78,7 +89,7 @@ behavior.
 ## Non-Goals
 
 - Network multiplayer.
-- Persistent saved games.
+- User-account persistence or multiplayer saved games.
 - Expert bridge bidding or card-play strategy.
 - Service-specific bridge platform integration. See
   `limited-information-bot-adapter.md` for the generic integration boundary.

--- a/web/e2e/bridge-table.spec.ts
+++ b/web/e2e/bridge-table.spec.ts
@@ -72,6 +72,46 @@ test('keeps move history scrollable instead of expanding the table', async ({ pa
   expect(layoutMetrics.historyHeight).toBeLessThanOrEqual(layoutMetrics.maxHeight + 1)
 })
 
+test('gives clear shared-game save feedback and lets users retry', async ({ page }) => {
+  let saveAttempts = 0
+  await page.route('**/api/training/games', async (route) => {
+    saveAttempts += 1
+    if (saveAttempts === 1) {
+      await route.fulfill({
+        status: 500,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'temporarily_unavailable' }),
+      })
+      return
+    }
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        ok: true,
+        recordId: '0123456789abcdef01234567',
+        storage: 'test',
+        policyVersion: '2026-06-16',
+      }),
+    })
+  })
+
+  await page.goto('/')
+  await page.getByText('South to bid').waitFor()
+  await page.getByRole('switch', { name: /share games/i }).click()
+  await expect(page.getByRole('status')).toContainText('Completed boards will be shared anonymously')
+
+  await playCurrentDeal(page)
+
+  await expect(page.getByRole('status')).toContainText('Board not saved')
+  await expect(page.getByRole('status')).toContainText('Your board is still here')
+
+  await page.getByRole('button', { name: 'Try again' }).click()
+
+  await expect(page.getByRole('status')).toContainText('Board shared')
+  expect(saveAttempts).toBe(2)
+})
+
 test('keeps the table usable on mobile screens', async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 844 })
 

--- a/web/src/components/BridgeApp.test.tsx
+++ b/web/src/components/BridgeApp.test.tsx
@@ -6,6 +6,7 @@ import { BridgeApp } from './BridgeApp'
 describe('BridgeApp', () => {
   afterEach(() => {
     vi.useRealTimers()
+    vi.unstubAllGlobals()
   })
 
   it('renders the table as the first screen', () => {
@@ -19,6 +20,8 @@ describe('BridgeApp', () => {
     expect(screen.getByText('Bot action')).not.toBeNull()
     expect(screen.getByText('Bidding')).not.toBeNull()
     expect(screen.getByText('Waiting')).not.toBeNull()
+    expect(screen.getByRole('checkbox', { name: /share games/i })).not.toBeNull()
+    expect(screen.getByRole('link', { name: /privacy/i }).getAttribute('href')).toBe('/privacy')
   })
 
   it('shows public move history instead of a bot pace control', () => {
@@ -149,4 +152,5 @@ describe('BridgeApp', () => {
     expect(container.querySelectorAll('.playing-card')).toHaveLength(52)
     expect(screen.queryAllByRole('button', { name: /play /i })).toHaveLength(0)
   })
+
 })

--- a/web/src/components/BridgeApp.test.tsx
+++ b/web/src/components/BridgeApp.test.tsx
@@ -20,7 +20,7 @@ describe('BridgeApp', () => {
     expect(screen.getByText('Bot action')).not.toBeNull()
     expect(screen.getByText('Bidding')).not.toBeNull()
     expect(screen.getByText('Waiting')).not.toBeNull()
-    expect(screen.getByRole('checkbox', { name: /share games/i })).not.toBeNull()
+    expect(screen.getByRole('switch', { name: /share games/i })).not.toBeNull()
     expect(screen.getByRole('link', { name: /privacy/i }).getAttribute('href')).toBe('/privacy')
   })
 
@@ -151,6 +151,15 @@ describe('BridgeApp', () => {
     expect(screen.getAllByLabelText(/hand/i).length).toBe(4)
     expect(container.querySelectorAll('.playing-card')).toHaveLength(52)
     expect(screen.queryAllByRole('button', { name: /play /i })).toHaveLength(0)
+  })
+
+  it('explains what shared game recording will do after opt-in', () => {
+    render(<BridgeApp />)
+
+    fireEvent.click(screen.getByRole('switch', { name: /share games/i }))
+
+    expect(screen.getByRole('status').textContent).toContain('Completed boards will be shared anonymously')
+    expect(screen.getByText('On after board')).not.toBeNull()
   })
 
 })

--- a/web/src/components/BridgeApp.tsx
+++ b/web/src/components/BridgeApp.tsx
@@ -41,6 +41,7 @@ export function BridgeApp() {
   const mobileTableLayout = useMobileTableLayout()
   const [shareTrainingGames, setShareTrainingGames] = useState(false)
   const [recordingStatus, setRecordingStatus] = useState<RecordingStatus>('off')
+  const [recordRetryToken, setRecordRetryToken] = useState(0)
   const recordedGameKey = useRef<string | null>(null)
   const [game, setGame] = useState(() => createGame({
     seats: defaultSeats,
@@ -83,14 +84,14 @@ export function BridgeApp() {
       return
     }
 
-    const gameKey = `${game.seed}:${boardIndex}:${game.phase}:${game.auction.length}:${game.completedTricks.length}`
+    const gameKey = `${game.seed}:${boardIndex}:${game.phase}:${game.auction.length}:${game.completedTricks.length}:${recordRetryToken}`
     if (recordedGameKey.current === gameKey) return
     recordedGameKey.current = gameKey
     setRecordingStatus('saving')
 
     void submitTrainingRecord(trainingRecordFromGame(game, boardIndex + 1))
       .then((result) => setRecordingStatus(result.ok ? 'saved' : 'failed'))
-  }, [boardIndex, game, shareTrainingGames])
+  }, [boardIndex, game, recordRetryToken, shareTrainingGames])
 
   function startDeal(next = seed, nextBoardIndex = boardIndex) {
     setSeed(next)
@@ -128,6 +129,12 @@ export function BridgeApp() {
     }))
   }
 
+  function retryRecording() {
+    if (!shareTrainingGames || !isRecordableTrainingGame(game) || recordingStatus === 'saving') return
+    recordedGameKey.current = null
+    setRecordRetryToken((current) => current + 1)
+  }
+
   function makeCall(call: Call) {
     setGame((current) => {
       if (current.phase !== 'auction' || !isCallLegal(current.auction, current.turn, call)) return current
@@ -157,6 +164,7 @@ export function BridgeApp() {
           recordingStatus={recordingStatus}
           onPractice={setPracticeMode}
           onShareTrainingGames={setShareTrainingGames}
+          onRetryRecording={retryRecording}
           onNewDeal={() => startDeal(nextSeed(), boardIndex + 1)}
           onStep={() => setGame((current) => advanceBotOnce(current))}
         />
@@ -255,6 +263,7 @@ function ControlRail({
   recordingStatus,
   onPractice,
   onShareTrainingGames,
+  onRetryRecording,
   onNewDeal,
   onStep,
 }: {
@@ -267,9 +276,12 @@ function ControlRail({
   recordingStatus: RecordingStatus
   onPractice: (enabled: boolean) => void
   onShareTrainingGames: (enabled: boolean) => void
+  onRetryRecording: () => void
   onNewDeal: () => void
   onStep: () => void
 }) {
+  const showRecordingStatus = shareTrainingGames || recordingStatus === 'failed' || recordingStatus === 'saved'
+
   return (
     <aside className="control-rail" aria-label="Table controls">
       <div>
@@ -288,18 +300,30 @@ function ControlRail({
         <RotateCcw aria-hidden="true" />
         <span>New</span>
       </button>
-      <label className={`record-toggle record-${recordingStatus}`}>
-        <input
-          type="checkbox"
-          checked={shareTrainingGames}
-          onChange={(event) => onShareTrainingGames(event.currentTarget.checked)}
-        />
+      <button
+        className={`record-toggle record-${recordingStatus}`}
+        type="button"
+        role="switch"
+        aria-checked={shareTrainingGames}
+        onClick={() => onShareTrainingGames(!shareTrainingGames)}
+      >
         <Database aria-hidden="true" />
         <span>
           <strong>Share games</strong>
           <small>{recordingStatusLabel(recordingStatus)}</small>
         </span>
-      </label>
+      </button>
+      {showRecordingStatus && (
+        <div className={`record-status record-${recordingStatus}`} role="status" aria-live="polite">
+          <strong>{recordingStatusTitle(recordingStatus)}</strong>
+          <span>{recordingStatusMessage(recordingStatus)}</span>
+          {recordingStatus === 'failed' && (
+            <button type="button" onClick={onRetryRecording}>
+              Try again
+            </button>
+          )}
+        </div>
+      )}
       <a className="privacy-link" href="/privacy">
         <ShieldCheck aria-hidden="true" />
         <span>Privacy</span>
@@ -319,8 +343,22 @@ function recordingStatusLabel(status: RecordingStatus) {
   if (status === 'ready') return 'On after board'
   if (status === 'saving') return 'Saving'
   if (status === 'saved') return 'Saved'
-  if (status === 'failed') return 'Retry next board'
+  if (status === 'failed') return 'Needs retry'
   return 'Off'
+}
+
+function recordingStatusTitle(status: RecordingStatus) {
+  if (status === 'saving') return 'Sharing board'
+  if (status === 'saved') return 'Board shared'
+  if (status === 'failed') return 'Board not saved'
+  return 'Sharing is on'
+}
+
+function recordingStatusMessage(status: RecordingStatus) {
+  if (status === 'saving') return 'Sending this completed board now.'
+  if (status === 'saved') return 'This anonymous board was accepted by the training endpoint.'
+  if (status === 'failed') return 'Your board is still here. Check the connection and retry.'
+  return 'Completed boards will be shared anonymously after they finish.'
 }
 
 function automationStatus(game: GameState) {

--- a/web/src/components/BridgeApp.tsx
+++ b/web/src/components/BridgeApp.tsx
@@ -1,4 +1,4 @@
-import { Bot, Eye, EyeOff, RotateCcw, StepForward, UserRound } from 'lucide-react'
+import { Bot, Database, Eye, EyeOff, RotateCcw, ShieldCheck, StepForward, UserRound } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
 import { callLabel, contractCalls, isCallLegal } from '../game/auction'
@@ -20,10 +20,12 @@ import {
   vulnerabilityForBoard,
   visibleSeatCards,
 } from '../game/engine'
+import { isRecordableTrainingGame, submitTrainingRecord, trainingRecordFromGame } from '../game/trainingRecord'
 import type { Call, Card, GameState, Seat, SeatConfig } from '../game/types'
 
 const compassSeats: Seat[] = ['N', 'E', 'S', 'W']
 const BOT_DELAY_MS = 420
+type RecordingStatus = 'off' | 'ready' | 'saving' | 'saved' | 'failed'
 
 function nextSeed() {
   return Math.floor(Date.now() % 1_000_000)
@@ -37,6 +39,9 @@ export function BridgeApp() {
   const [readySeat, setReadySeat] = useState<Seat | null>(null)
   const [thinkingSeat, setThinkingSeat] = useState<Seat | null>(null)
   const mobileTableLayout = useMobileTableLayout()
+  const [shareTrainingGames, setShareTrainingGames] = useState(false)
+  const [recordingStatus, setRecordingStatus] = useState<RecordingStatus>('off')
+  const recordedGameKey = useRef<string | null>(null)
   const [game, setGame] = useState(() => createGame({
     seats: defaultSeats,
     practice: false,
@@ -67,6 +72,25 @@ export function BridgeApp() {
       setReadySeat(null)
     }
   }, [humans.length, practice, game.turn])
+
+  useEffect(() => {
+    if (!shareTrainingGames) {
+      setRecordingStatus('off')
+      return
+    }
+    if (!isRecordableTrainingGame(game)) {
+      setRecordingStatus('ready')
+      return
+    }
+
+    const gameKey = `${game.seed}:${boardIndex}:${game.phase}:${game.auction.length}:${game.completedTricks.length}`
+    if (recordedGameKey.current === gameKey) return
+    recordedGameKey.current = gameKey
+    setRecordingStatus('saving')
+
+    void submitTrainingRecord(trainingRecordFromGame(game, boardIndex + 1))
+      .then((result) => setRecordingStatus(result.ok ? 'saved' : 'failed'))
+  }, [boardIndex, game, shareTrainingGames])
 
   function startDeal(next = seed, nextBoardIndex = boardIndex) {
     setSeed(next)
@@ -129,7 +153,10 @@ export function BridgeApp() {
           practice={practice}
           boardNumber={boardIndex + 1}
           showHistory={!mobileTableLayout}
+          shareTrainingGames={shareTrainingGames}
+          recordingStatus={recordingStatus}
           onPractice={setPracticeMode}
+          onShareTrainingGames={setShareTrainingGames}
           onNewDeal={() => startDeal(nextSeed(), boardIndex + 1)}
           onStep={() => setGame((current) => advanceBotOnce(current))}
         />
@@ -224,7 +251,10 @@ function ControlRail({
   practice,
   boardNumber,
   showHistory,
+  shareTrainingGames,
+  recordingStatus,
   onPractice,
+  onShareTrainingGames,
   onNewDeal,
   onStep,
 }: {
@@ -233,7 +263,10 @@ function ControlRail({
   practice: boolean
   boardNumber: number
   showHistory: boolean
+  shareTrainingGames: boolean
+  recordingStatus: RecordingStatus
   onPractice: (enabled: boolean) => void
+  onShareTrainingGames: (enabled: boolean) => void
   onNewDeal: () => void
   onStep: () => void
 }) {
@@ -255,6 +288,22 @@ function ControlRail({
         <RotateCcw aria-hidden="true" />
         <span>New</span>
       </button>
+      <label className={`record-toggle record-${recordingStatus}`}>
+        <input
+          type="checkbox"
+          checked={shareTrainingGames}
+          onChange={(event) => onShareTrainingGames(event.currentTarget.checked)}
+        />
+        <Database aria-hidden="true" />
+        <span>
+          <strong>Share games</strong>
+          <small>{recordingStatusLabel(recordingStatus)}</small>
+        </span>
+      </label>
+      <a className="privacy-link" href="/privacy">
+        <ShieldCheck aria-hidden="true" />
+        <span>Privacy</span>
+      </a>
       <div className="rail-status">
         <span>Board {boardNumber}</span>
         <span>{humans} human{humans === 1 ? '' : 's'}</span>
@@ -264,6 +313,14 @@ function ControlRail({
       {showHistory && <MoveHistory game={game} className="rail-history" />}
     </aside>
   )
+}
+
+function recordingStatusLabel(status: RecordingStatus) {
+  if (status === 'ready') return 'On after board'
+  if (status === 'saving') return 'Saving'
+  if (status === 'saved') return 'Saved'
+  if (status === 'failed') return 'Retry next board'
+  return 'Off'
 }
 
 function automationStatus(game: GameState) {

--- a/web/src/game/trainingRecord.test.ts
+++ b/web/src/game/trainingRecord.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createGame, defaultSeats } from './engine'
+import { PRIVACY_POLICY_VERSION, TRAINING_RECORD_SCHEMA, submitTrainingRecord, trainingRecordFromGame } from './trainingRecord'
+
+describe('training records', () => {
+  it('serializes completed games without browser or player identifiers', () => {
+    const game = {
+      ...createGame({ seats: defaultSeats, practice: false, seed: 20260615, dealer: 'N', vulnerability: 'None' }),
+      phase: 'passedOut' as const,
+    }
+
+    const record = trainingRecordFromGame(game, 1, '2026-06-16T00:00:00.000Z')
+    const serialized = JSON.stringify(record)
+
+    expect(record.schema).toBe(TRAINING_RECORD_SCHEMA)
+    expect(record.consent).toEqual({
+      shareForTraining: true,
+      privacyPolicyVersion: PRIVACY_POLICY_VERSION,
+    })
+    expect(record.game.boardNumber).toBe(1)
+    expect(record.game.hands.N).toHaveLength(13)
+    expect(serialized).not.toMatch(/userAgent|playerName|sessionId|visitorId|email/i)
+  })
+
+  it('rejects unfinished games', () => {
+    const game = createGame({ seats: defaultSeats, practice: false, seed: 20260615 })
+
+    expect(() => trainingRecordFromGame(game, 1)).toThrow(/completed or passed-out/i)
+  })
+
+  it('submits records to the same-origin training endpoint by default', async () => {
+    const game = {
+      ...createGame({ seats: defaultSeats, practice: false, seed: 20260615, dealer: 'N', vulnerability: 'None' }),
+      phase: 'passedOut' as const,
+    }
+    const record = trainingRecordFromGame(game, 1, '2026-06-16T00:00:00.000Z')
+    const fetcher = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        ok: true,
+        recordId: '0123456789abcdef01234567',
+        storage: 'r2',
+        policyVersion: PRIVACY_POLICY_VERSION,
+      }),
+    })
+
+    const result = await submitTrainingRecord(record, fetcher)
+    expect(fetcher.mock.calls[0]).toBeDefined()
+    const [url, options] = fetcher.mock.calls[0]!
+    const body = JSON.parse(options.body)
+
+    expect(result).toEqual({
+      ok: true,
+      recordId: '0123456789abcdef01234567',
+      storage: 'r2',
+      policyVersion: PRIVACY_POLICY_VERSION,
+    })
+    expect(url).toBe('/api/training/games')
+    expect(options.method).toBe('POST')
+    expect(options.headers).toEqual({ 'Content-Type': 'application/json' })
+    expect(body.schema).toBe(TRAINING_RECORD_SCHEMA)
+    expect(body.consent.shareForTraining).toBe(true)
+  })
+})

--- a/web/src/game/trainingRecord.ts
+++ b/web/src/game/trainingRecord.ts
@@ -1,0 +1,99 @@
+import type { GameState } from './types'
+
+export const TRAINING_RECORD_SCHEMA = 'bridgebot.training_game.v1'
+export const PRIVACY_POLICY_VERSION = '2026-06-16'
+
+export type TrainingRecord = {
+  schema: typeof TRAINING_RECORD_SCHEMA
+  source: 'bridgebot-web'
+  recordedAt: string
+  consent: {
+    shareForTraining: true
+    privacyPolicyVersion: typeof PRIVACY_POLICY_VERSION
+  }
+  game: {
+    boardNumber: number
+    seed: number
+    dealer: GameState['dealer']
+    vulnerability: GameState['vulnerability']
+    phase: 'complete' | 'passedOut'
+    seats: GameState['seats']
+    hands: GameState['hands']
+    auction: GameState['auction']
+    contract: GameState['contract']
+    currentTrick: GameState['currentTrick']
+    completedTricks: GameState['completedTricks']
+    tricksWon: GameState['tricksWon']
+    score: GameState['score']
+  }
+}
+
+export type TrainingSubmitResult =
+  | { ok: true; recordId: string; storage: string; policyVersion: string }
+  | { ok: false; reason: 'network' | 'server'; status?: number }
+
+export function isRecordableTrainingGame(game: GameState): game is GameState & { phase: 'complete' | 'passedOut' } {
+  return game.phase === 'complete' || game.phase === 'passedOut'
+}
+
+export function trainingRecordFromGame(
+  game: GameState,
+  boardNumber: number,
+  recordedAt = new Date().toISOString(),
+): TrainingRecord {
+  if (!isRecordableTrainingGame(game)) {
+    throw new Error('Only completed or passed-out games can be recorded for training.')
+  }
+
+  return {
+    schema: TRAINING_RECORD_SCHEMA,
+    source: 'bridgebot-web',
+    recordedAt,
+    consent: {
+      shareForTraining: true,
+      privacyPolicyVersion: PRIVACY_POLICY_VERSION,
+    },
+    game: {
+      boardNumber,
+      seed: game.seed,
+      dealer: game.dealer,
+      vulnerability: game.vulnerability,
+      phase: game.phase,
+      seats: game.seats,
+      hands: game.hands,
+      auction: game.auction,
+      contract: game.contract,
+      currentTrick: game.currentTrick,
+      completedTricks: game.completedTricks,
+      tricksWon: game.tricksWon,
+      score: game.score,
+    },
+  }
+}
+
+export async function submitTrainingRecord(
+  record: TrainingRecord,
+  fetcher: typeof fetch = fetch,
+): Promise<TrainingSubmitResult> {
+  try {
+    const response = await fetcher(trainingEndpoint(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(record),
+    })
+
+    if (!response.ok) {
+      return { ok: false, reason: 'server', status: response.status }
+    }
+
+    return await response.json() as TrainingSubmitResult
+  } catch {
+    return { ok: false, reason: 'network' }
+  }
+}
+
+function trainingEndpoint() {
+  const configuredBase = import.meta.env.VITE_BRIDGEBOT_API_URL?.trim()
+  if (!configuredBase) return '/api/training/games'
+  return `${configuredBase.replace(/\/+$/, '')}/api/training/games`
+}

--- a/web/src/routeTree.gen.ts
+++ b/web/src/routeTree.gen.ts
@@ -9,8 +9,14 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as PrivacyRouteImport } from './routes/privacy'
 import { Route as IndexRouteImport } from './routes/index'
 
+const PrivacyRoute = PrivacyRouteImport.update({
+  id: '/privacy',
+  path: '/privacy',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
@@ -19,28 +25,39 @@ const IndexRoute = IndexRouteImport.update({
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
+  '/privacy': typeof PrivacyRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
+  '/privacy': typeof PrivacyRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
+  '/privacy': typeof PrivacyRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/'
+  fullPaths: '/' | '/privacy'
   fileRoutesByTo: FileRoutesByTo
-  to: '/'
-  id: '__root__' | '/'
+  to: '/' | '/privacy'
+  id: '__root__' | '/' | '/privacy'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
+  PrivacyRoute: typeof PrivacyRoute
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/privacy': {
+      id: '/privacy'
+      path: '/privacy'
+      fullPath: '/privacy'
+      preLoaderRoute: typeof PrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/': {
       id: '/'
       path: '/'
@@ -53,6 +70,7 @@ declare module '@tanstack/react-router' {
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
+  PrivacyRoute: PrivacyRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/web/src/routes/privacy.tsx
+++ b/web/src/routes/privacy.tsx
@@ -1,0 +1,52 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+export const Route = createFileRoute('/privacy')({
+  component: PrivacyPage,
+})
+
+function PrivacyPage() {
+  return (
+    <main className="privacy-page">
+      <article>
+        <a href="/">Back to table</a>
+        <span className="eyebrow">Bridge Bot</span>
+        <h1>Privacy Policy</h1>
+        <p>Effective June 16, 2026.</p>
+
+        <h2>Game Recording</h2>
+        <p>
+          Game sharing is off by default. If you turn it on, Bridge Bot sends
+          completed or passed-out boards to the backend so they can be used for
+          bot training and evaluation.
+        </p>
+
+        <h2>What We Store</h2>
+        <ul>
+          <li>Board number, seed, dealer, vulnerability, and final phase.</li>
+          <li>Seat controller types, auction, contract, tricks, score, and final hands.</li>
+          <li>The privacy policy version attached to the consented record.</li>
+        </ul>
+
+        <h2>What We Do Not Store</h2>
+        <ul>
+          <li>Names, email addresses, account IDs, session IDs, or visitor IDs.</li>
+          <li>IP addresses, user agents, browser details, or device details.</li>
+          <li>Anything typed by a player, because the table has no chat or profile fields.</li>
+        </ul>
+
+        <h2>Training Use</h2>
+        <p>
+          Shared games may be used to compare bot policies, train future bridge
+          models, test scoring and bidding behavior, and improve gameplay
+          quality. Records are anonymous table data, not user profiles.
+        </p>
+
+        <h2>Control</h2>
+        <p>
+          Turn off Share games at any time to stop sending future boards. Boards
+          already accepted by the backend may remain in the training dataset.
+        </p>
+      </article>
+    </main>
+  )
+}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -61,7 +61,7 @@ input:focus-visible {
 
 .control-rail {
   display: grid;
-  grid-template-rows: auto auto auto auto auto minmax(0, 1fr);
+  grid-template-rows: auto auto auto auto auto auto auto minmax(0, 1fr);
   align-content: start;
   gap: 12px;
   min-width: 0;
@@ -100,6 +100,8 @@ input:focus-visible {
 .icon-button,
 .primary-action,
 .seat-toggle,
+.record-toggle,
+.privacy-link,
 .bid-actions button,
 .bid-grid button {
   min-height: 38px;
@@ -123,7 +125,9 @@ input:focus-visible {
 
 .icon-button svg,
 .primary-action svg,
-.seat-toggle svg {
+.seat-toggle svg,
+.record-toggle svg,
+.privacy-link svg {
   width: 17px;
   height: 17px;
 }
@@ -137,10 +141,61 @@ input:focus-visible {
 
 .icon-button:not(:disabled):hover,
 .seat-toggle:not(:disabled):hover,
+.privacy-link:hover,
 .bid-actions button:not(:disabled):hover,
 .bid-grid button:not(:disabled):hover {
   border-color: rgba(244, 207, 121, 0.72);
   background: rgba(255, 247, 224, 0.14);
+}
+
+.record-toggle {
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+}
+
+.record-toggle input {
+  width: 16px;
+  height: 16px;
+  accent-color: #d6b15b;
+}
+
+.record-toggle span {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.record-toggle strong,
+.privacy-link span {
+  font-size: 0.78rem;
+  line-height: 1.1;
+}
+
+.record-toggle small {
+  color: #d6c5a2;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+}
+
+.record-saved {
+  border-color: rgba(141, 187, 141, 0.62);
+}
+
+.record-failed {
+  border-color: rgba(183, 47, 53, 0.72);
+}
+
+.privacy-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 7px;
+  padding: 8px;
+  color: #f7ecd2;
+  text-decoration: none;
 }
 
 .primary-action:not(:disabled):hover {
@@ -678,6 +733,44 @@ input:focus-visible {
   color: #d8c69e;
 }
 
+.privacy-page {
+  min-height: 100vh;
+  background: #10241d;
+  color: #f5ecd8;
+  padding: clamp(20px, 5vw, 56px);
+}
+
+.privacy-page article {
+  max-width: 780px;
+}
+
+.privacy-page a {
+  color: #f0cb72;
+}
+
+.privacy-page h1 {
+  margin: 18px 0;
+  font-size: clamp(2rem, 5vw, 3.6rem);
+  line-height: 1;
+}
+
+.privacy-page h2 {
+  margin: 28px 0 8px;
+  color: #f0cb72;
+  font-size: 1.05rem;
+  text-transform: uppercase;
+}
+
+.privacy-page p,
+.privacy-page li {
+  color: #e2d5b9;
+  line-height: 1.6;
+}
+
+.privacy-page ul {
+  padding-left: 20px;
+}
+
 @keyframes pulse {
   0%,
   100% {
@@ -761,6 +854,8 @@ input:focus-visible {
   }
 
   .control-rail > div:first-child,
+  .record-toggle,
+  .privacy-link,
   .rail-status {
     grid-column: 1 / -1;
   }

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -150,16 +150,11 @@ input:focus-visible {
 
 .record-toggle {
   display: grid;
-  grid-template-columns: auto auto minmax(0, 1fr);
+  grid-template-columns: auto minmax(0, 1fr);
   align-items: center;
+  text-align: left;
   gap: 8px;
   padding: 8px;
-}
-
-.record-toggle input {
-  width: 16px;
-  height: 16px;
-  accent-color: #d6b15b;
 }
 
 .record-toggle span {
@@ -186,6 +181,55 @@ input:focus-visible {
 
 .record-failed {
   border-color: rgba(183, 47, 53, 0.72);
+}
+
+.record-status {
+  display: grid;
+  gap: 5px;
+  min-width: 0;
+  padding: 9px;
+  border: 1px solid rgba(232, 207, 139, 0.2);
+  background: rgba(255, 247, 224, 0.055);
+}
+
+.record-status strong {
+  color: #f5ecd8;
+  font-size: 0.82rem;
+  line-height: 1.1;
+}
+
+.record-status span {
+  color: #d9cbaa;
+  font-size: 0.74rem;
+  line-height: 1.3;
+}
+
+.record-status button {
+  justify-self: start;
+  min-height: 32px;
+  margin-top: 2px;
+  padding: 5px 8px;
+  border: 1px solid rgba(244, 207, 121, 0.46);
+  background: rgba(244, 207, 121, 0.14);
+  color: #f7ecd2;
+}
+
+.record-status button:hover {
+  border-color: rgba(244, 207, 121, 0.8);
+  background: rgba(244, 207, 121, 0.22);
+}
+
+.record-status.record-saving {
+  border-color: rgba(244, 207, 121, 0.42);
+}
+
+.record-status.record-saved {
+  border-color: rgba(141, 187, 141, 0.52);
+}
+
+.record-status.record-failed {
+  border-color: rgba(183, 47, 53, 0.7);
+  background: rgba(183, 47, 53, 0.12);
 }
 
 .privacy-link {
@@ -855,6 +899,7 @@ input:focus-visible {
 
   .control-rail > div:first-child,
   .record-toggle,
+  .record-status,
   .privacy-link,
   .rail-status {
     grid-column: 1 / -1;
@@ -874,6 +919,7 @@ input:focus-visible {
   .icon-button,
   .primary-action,
   .seat-toggle,
+  .record-status button,
   .bid-actions button,
   .bid-grid button {
     min-height: 44px;

--- a/workers/backend/src/bridgebot_api.py
+++ b/workers/backend/src/bridgebot_api.py
@@ -1,8 +1,13 @@
+import hashlib
 import json
 from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
 
+
+PRIVACY_POLICY_VERSION = "2026-06-16"
+TRAINING_RECORD_SCHEMA = "bridgebot.training_game.v1"
+MAX_TRAINING_GAME_BYTES = 128_000
 
 FORBIDDEN_STATE_KEYS = {
     "all_hands",
@@ -14,6 +19,27 @@ FORBIDDEN_STATE_KEYS = {
     "eastHand",
     "southHand",
     "westHand",
+}
+
+FORBIDDEN_PERSONAL_KEYS = {
+    "account",
+    "accountId",
+    "browser",
+    "device",
+    "email",
+    "ip",
+    "ipAddress",
+    "name",
+    "playerId",
+    "playerName",
+    "rawRequest",
+    "session",
+    "sessionId",
+    "user",
+    "userAgent",
+    "username",
+    "visitor",
+    "visitorId",
 }
 
 PUBLIC_VIEW_KEYS = {
@@ -39,6 +65,14 @@ class ApiResponse:
     body: str
 
 
+@dataclass(frozen=True)
+class PreparedTrainingRecord:
+    record_id: str
+    storage_key: str
+    body: str
+    payload: dict[str, Any]
+
+
 def handle_request(method: str, url: str, body: str | None = None) -> ApiResponse:
     path = urlparse(url).path
     normalized_method = method.upper()
@@ -56,7 +90,105 @@ def handle_request(method: str, url: str, body: str | None = None) -> ApiRespons
     if normalized_method == "POST" and path == "/api/bot/action":
         return _bot_action(body)
 
+    if normalized_method == "POST" and path == "/api/training/games":
+        record = prepare_training_game_record(body)
+        if isinstance(record, ApiResponse):
+            return record
+        return training_game_response(record)
+
     return _json_response({"error": "not_found"}, status=404)
+
+
+def prepare_training_game_record(body: str | None) -> PreparedTrainingRecord | ApiResponse:
+    if body is not None and len(body.encode("utf-8")) > MAX_TRAINING_GAME_BYTES:
+        return _json_response({
+            "error": "training_game_too_large",
+            "maxBytes": MAX_TRAINING_GAME_BYTES,
+        }, status=413)
+
+    payload = _load_json_object(body)
+    if isinstance(payload, ApiResponse):
+        return payload
+
+    personal_key = _first_forbidden_key(payload, forbidden_keys=FORBIDDEN_PERSONAL_KEYS)
+    if personal_key is not None:
+        return _json_response({
+            "error": "personal_data_rejected",
+            "message": f"Payload includes personal-data key: {personal_key}",
+        }, status=400)
+
+    if payload.get("schema") != TRAINING_RECORD_SCHEMA:
+        return _json_response({
+            "error": "invalid_training_schema",
+            "message": f"schema must be {TRAINING_RECORD_SCHEMA}",
+        }, status=422)
+
+    consent = payload.get("consent")
+    if not isinstance(consent, dict) or consent.get("shareForTraining") is not True:
+        return _json_response({
+            "error": "training_consent_required",
+            "message": "shareForTraining consent must be true before storing a game.",
+        }, status=422)
+
+    game = payload.get("game")
+    if not isinstance(game, dict):
+        return _json_response({"error": "invalid_training_game"}, status=422)
+
+    if game.get("phase") not in {"complete", "passedOut"}:
+        return _json_response({
+            "error": "unfinished_training_game",
+            "message": "Only completed or passed-out games may be recorded for training.",
+        }, status=422)
+
+    required_game_keys = {
+        "auction",
+        "boardNumber",
+        "dealer",
+        "hands",
+        "phase",
+        "seed",
+        "seats",
+        "tricksWon",
+        "vulnerability",
+    }
+    missing_game_keys = sorted(required_game_keys - set(game))
+    if missing_game_keys:
+        return _json_response({
+            "error": "training_game_missing_keys",
+            "keys": missing_game_keys,
+        }, status=422)
+
+    normalized = {
+        "schema": TRAINING_RECORD_SCHEMA,
+        "source": payload.get("source", "bridgebot-web"),
+        "policyVersion": PRIVACY_POLICY_VERSION,
+        "consent": {
+            "shareForTraining": True,
+            "privacyPolicyVersion": consent.get("privacyPolicyVersion", PRIVACY_POLICY_VERSION),
+        },
+        "game": game,
+    }
+
+    if "recordedAt" in payload:
+        normalized["recordedAt"] = payload["recordedAt"]
+
+    record_body = json.dumps(normalized, sort_keys=True, separators=(",", ":"))
+    record_id = hashlib.sha256(record_body.encode("utf-8")).hexdigest()[:24]
+    return PreparedTrainingRecord(
+        record_id=record_id,
+        storage_key=f"training-games/v1/{record_id}.json",
+        body=record_body,
+        payload=normalized,
+    )
+
+
+def training_game_response(record: PreparedTrainingRecord, storage: str = "not_configured") -> ApiResponse:
+    return _json_response({
+        "ok": True,
+        "recordId": record.record_id,
+        "storage": storage,
+        "policyVersion": PRIVACY_POLICY_VERSION,
+    }, status=202)
 
 
 def _bot_action(body: str | None) -> ApiResponse:
@@ -64,7 +196,7 @@ def _bot_action(body: str | None) -> ApiResponse:
     if isinstance(payload, ApiResponse):
         return payload
 
-    leak_path = _first_forbidden_key(payload)
+    leak_path = _first_forbidden_key(payload, forbidden_keys=FORBIDDEN_STATE_KEYS)
     if leak_path is not None:
         return _json_response({
             "error": "hidden_state_rejected",
@@ -147,18 +279,19 @@ def _load_json_object(body: str | None) -> dict[str, Any] | ApiResponse:
     return payload
 
 
-def _first_forbidden_key(value: Any, prefix: str = "") -> str | None:
+def _first_forbidden_key(value: Any, prefix: str = "", forbidden_keys: set[str] | None = None) -> str | None:
+    forbidden = forbidden_keys or FORBIDDEN_STATE_KEYS
     if isinstance(value, dict):
         for key, child in value.items():
             path = f"{prefix}.{key}" if prefix else str(key)
-            if key in FORBIDDEN_STATE_KEYS:
+            if key in forbidden:
                 return path
-            nested = _first_forbidden_key(child, path)
+            nested = _first_forbidden_key(child, path, forbidden)
             if nested is not None:
                 return nested
     elif isinstance(value, list):
         for index, child in enumerate(value):
-            nested = _first_forbidden_key(child, f"{prefix}[{index}]")
+            nested = _first_forbidden_key(child, f"{prefix}[{index}]", forbidden)
             if nested is not None:
                 return nested
     return None

--- a/workers/backend/src/entry.py
+++ b/workers/backend/src/entry.py
@@ -1,6 +1,13 @@
+from urllib.parse import urlparse
+
 from workers import Response, WorkerEntrypoint
 
-from bridgebot_api import handle_request
+from bridgebot_api import (
+    ApiResponse,
+    handle_request,
+    prepare_training_game_record,
+    training_game_response,
+)
 
 
 class Default(WorkerEntrypoint):
@@ -9,5 +16,21 @@ class Default(WorkerEntrypoint):
         if request.method.upper() not in ("GET", "HEAD", "OPTIONS"):
             body = await request.text()
 
+        if request.method.upper() == "POST" and urlparse(request.url).path == "/api/training/games":
+            response = await self._training_game_response(body)
+            return Response(response.body, status=response.status, headers=response.headers)
+
         response = handle_request(request.method, request.url, body)
         return Response(response.body, status=response.status, headers=response.headers)
+
+    async def _training_game_response(self, body):
+        record = prepare_training_game_record(body)
+        if isinstance(record, ApiResponse):
+            return record
+
+        bucket = getattr(self.env, "TRAINING_GAMES", None)
+        if bucket is None:
+            return training_game_response(record)
+
+        await bucket.put(record.storage_key, record.body)
+        return training_game_response(record, storage="r2")

--- a/workers/backend/tests/test_bridgebot_api.py
+++ b/workers/backend/tests/test_bridgebot_api.py
@@ -1,6 +1,6 @@
 import json
 
-from bridgebot_api import handle_request
+from bridgebot_api import TRAINING_RECORD_SCHEMA, handle_request
 
 
 def response_json(response):
@@ -117,3 +117,105 @@ def test_bot_action_rejects_unknown_view_keys():
 
     assert response.status == 400
     assert body == {"error": "unknown_view_keys", "keys": ["opponentModel"]}
+
+
+def test_training_game_record_accepts_completed_anonymous_game():
+    response = handle_request(
+        "POST",
+        "https://bridgebot-api.example/api/training/games",
+        json.dumps(training_game_payload()),
+    )
+
+    body = response_json(response)
+
+    assert response.status == 202
+    assert body["ok"] is True
+    assert len(body["recordId"]) == 24
+    assert body["storage"] == "not_configured"
+    assert body["policyVersion"] == "2026-06-16"
+
+
+def test_training_game_record_requires_explicit_consent():
+    payload = training_game_payload()
+    payload["consent"]["shareForTraining"] = False
+
+    response = handle_request(
+        "POST",
+        "https://bridgebot-api.example/api/training/games",
+        json.dumps(payload),
+    )
+
+    body = response_json(response)
+
+    assert response.status == 422
+    assert body["error"] == "training_consent_required"
+
+
+def test_training_game_record_rejects_unfinished_games():
+    payload = training_game_payload()
+    payload["game"]["phase"] = "play"
+
+    response = handle_request(
+        "POST",
+        "https://bridgebot-api.example/api/training/games",
+        json.dumps(payload),
+    )
+
+    body = response_json(response)
+
+    assert response.status == 422
+    assert body["error"] == "unfinished_training_game"
+
+
+def test_training_game_record_rejects_personal_data_keys():
+    payload = training_game_payload()
+    payload["game"]["playerName"] = "North Player"
+
+    response = handle_request(
+        "POST",
+        "https://bridgebot-api.example/api/training/games",
+        json.dumps(payload),
+    )
+
+    body = response_json(response)
+
+    assert response.status == 400
+    assert body["error"] == "personal_data_rejected"
+    assert "playerName" in body["message"]
+
+
+def training_game_payload():
+    return {
+        "schema": TRAINING_RECORD_SCHEMA,
+        "source": "bridgebot-web",
+        "recordedAt": "2026-06-16T00:00:00.000Z",
+        "consent": {
+            "shareForTraining": True,
+            "privacyPolicyVersion": "2026-06-16",
+        },
+        "game": {
+            "boardNumber": 1,
+            "seed": 20260615,
+            "dealer": "N",
+            "vulnerability": "None",
+            "phase": "passedOut",
+            "seats": {"N": "bot", "E": "bot", "S": "human", "W": "bot"},
+            "hands": {
+                "N": [{"id": "AS", "suit": "S", "rank": 14}],
+                "E": [{"id": "2C", "suit": "C", "rank": 2}],
+                "S": [{"id": "3D", "suit": "D", "rank": 3}],
+                "W": [{"id": "4H", "suit": "H", "rank": 4}],
+            },
+            "auction": [
+                {"seat": "N", "call": {"kind": "pass"}},
+                {"seat": "E", "call": {"kind": "pass"}},
+                {"seat": "S", "call": {"kind": "pass"}},
+                {"seat": "W", "call": {"kind": "pass"}},
+            ],
+            "contract": None,
+            "currentTrick": [],
+            "completedTricks": [],
+            "tricksWon": {"NS": 0, "EW": 0},
+            "score": None,
+        },
+    }

--- a/workers/backend/wrangler.jsonc
+++ b/workers/backend/wrangler.jsonc
@@ -3,6 +3,13 @@
   "main": "src/entry.py",
   "compatibility_date": "2026-06-15",
   "compatibility_flags": ["python_workers"],
+  "r2_buckets": [
+    {
+      "binding": "TRAINING_GAMES",
+      "bucket_name": "bridgebot-training-games",
+      "preview_bucket_name": "bridgebot-training-games-preview"
+    }
+  ],
   "observability": {
     "enabled": true
   }


### PR DESCRIPTION
## Summary
- adds opt-in Share games control and /privacy route to the table
- serializes only completed or passed-out games for training
- adds POST /api/training/games with schema, consent, terminal-phase, size, and personal-data-key validation
- stores accepted backend records in the TRAINING_GAMES R2 binding when configured
- updates README and RST/spec docs for privacy and Cloudflare R2 setup

## Verification
- pytest workers/backend/tests/test_bridgebot_api.py -> 9 passed on feature/privacy-training-records
- pnpm --dir web test -> 32 passed
- pnpm --dir web typecheck
- pnpm --dir web cf:dry-run
- cd workers/backend && uv run pywrangler deploy --dry-run (confirmed env.TRAINING_GAMES binding)

## Stack
- Stacked on #12 / feature/cloudflare-deploy because it extends the deployed web/backend surfaces.

## Notes
- The MIT license PR is intentionally not included yet.