### PR TITLE
Keep unplayable cards visible during play

### DIFF
--- a/web/e2e/bridge-table.spec.ts
+++ b/web/e2e/bridge-table.spec.ts
@@ -38,6 +38,41 @@ test('shows only legal human choices and keeps other hands hidden outside practi
   expect(controls.map((control) => control.name)).not.toContain('1H')
 })
 
+test('keeps unplayable human cards visible and disabled during play', async ({ page }) => {
+  await page.goto('/')
+
+  for (let actionCount = 0; actionCount < 120; actionCount += 1) {
+    const dealText = await page.locator('.rail-status').innerText()
+    if (/Board complete|Board passed out|Complete|Passed out/.test(dealText)) break
+
+    const blockedCards = page.locator('.seat-S button.playing-card.blocked')
+    if (await blockedCards.count() > 0) {
+      const visibleCards = await page.locator('.seat-S .playing-card').count()
+      const playableCards = await page.locator('.seat-S button[aria-label^="Play "]:not([disabled])').count()
+      const blockedCard = blockedCards.first()
+
+      expect(visibleCards).toBeGreaterThan(playableCards)
+      await expect(blockedCard).toBeDisabled()
+      await expect(blockedCard).toHaveAttribute('aria-label', /cannot be played/)
+      return
+    }
+
+    if (await clickIfEnabled(page.getByRole('button', { name: 'Pass' }))) continue
+
+    const playableCard = page.locator('.seat-S button[aria-label^="Play "]:not([disabled])').first()
+    if (await playableCard.isVisible().catch(() => false)) {
+      await playableCard.click()
+      continue
+    }
+
+    if (await clickIfEnabled(page.getByRole('button', { name: 'Step' }))) continue
+
+    await page.waitForTimeout(80)
+  }
+
+  throw new Error('No human follow-suit turn with disabled cards appeared in the test deal.')
+})
+
 test('keeps move history scrollable instead of expanding the table', async ({ page }) => {
   await page.setViewportSize({ width: 1000, height: 700 })
 

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,5 +1,8 @@
 import { defineConfig, devices } from '@playwright/test'
 
+const port = process.env.BRIDGEBOT_E2E_PORT ?? '3000'
+const baseURL = `http://127.0.0.1:${port}`
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
@@ -9,7 +12,7 @@ export default defineConfig({
   },
   reporter: [['list']],
   use: {
-    baseURL: 'http://127.0.0.1:3000',
+    baseURL,
     trace: 'on-first-retry',
   },
   projects: [
@@ -19,9 +22,9 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: 'pnpm dev',
-    url: 'http://127.0.0.1:3000',
-    reuseExistingServer: !process.env.CI,
+    command: `pnpm dev --port ${port}`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI && !process.env.BRIDGEBOT_E2E_PORT,
     timeout: 120_000,
   },
 })

--- a/web/src/components/BridgeApp.test.tsx
+++ b/web/src/components/BridgeApp.test.tsx
@@ -1,7 +1,15 @@
 import { act, fireEvent, render, screen, within } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { BridgeApp } from './BridgeApp'
+import type { Card, GameState } from '../game/types'
+import { BridgeApp, SeatPanel } from './BridgeApp'
+
+function card(id: string): Card {
+  const suit = id[0] as Card['suit']
+  const label = id.slice(1)
+  const rank = ({ J: 11, Q: 12, K: 13, A: 14 } as Record<string, number>)[label] ?? Number(label)
+  return { id, suit, rank: rank as Card['rank'] }
+}
 
 describe('BridgeApp', () => {
   afterEach(() => {
@@ -148,5 +156,59 @@ describe('BridgeApp', () => {
     expect(screen.getAllByLabelText(/hand/i).length).toBe(4)
     expect(container.querySelectorAll('.playing-card')).toHaveLength(52)
     expect(screen.queryAllByRole('button', { name: /play /i })).toHaveLength(0)
+  })
+
+  it('keeps the full hand visible and disables cards that cannot follow suit', () => {
+    const ledHeart = card('H2')
+    const playableHeart = card('H3')
+    const blockedClub = card('C4')
+    const game: GameState = {
+      phase: 'play',
+      seats: { N: 'bot', E: 'bot', S: 'human', W: 'bot' },
+      practice: false,
+      seed: 1,
+      dealer: 'N',
+      vulnerability: 'None',
+      hands: {
+        N: [],
+        E: [],
+        S: [playableHeart, blockedClub],
+        W: [],
+      },
+      auction: [],
+      contract: { level: 1, strain: 'NT', declarer: 'N', bidder: 'N', doubled: 'none' },
+      turn: 'S',
+      leader: 'E',
+      currentTrick: [{ seat: 'E', card: ledHeart }],
+      completedTricks: [],
+      tricksWon: { NS: 0, EW: 0 },
+      score: null,
+    }
+    const onPlay = vi.fn()
+
+    render(
+      <SeatPanel
+        seat="S"
+        game={game}
+        visible
+        thinking={false}
+        canAct
+        onPlay={onPlay}
+      />,
+    )
+
+    const playable = screen.getByRole('button', { name: 'Play 3♥' }) as HTMLButtonElement
+    const blocked = screen.getByRole('button', { name: '4♣ cannot be played' }) as HTMLButtonElement
+
+    expect(screen.getByLabelText(/south hand/i).querySelectorAll('.playing-card')).toHaveLength(2)
+    expect(playable.disabled).toBe(false)
+    expect(blocked.disabled).toBe(true)
+    expect(blocked.className).toContain('blocked')
+
+    fireEvent.click(blocked)
+    expect(onPlay).not.toHaveBeenCalled()
+
+    fireEvent.click(playable)
+    expect(onPlay).toHaveBeenCalledWith('S', playableHeart)
   })
 })

--- a/web/src/components/BridgeApp.tsx
+++ b/web/src/components/BridgeApp.tsx
@@ -389,7 +389,7 @@ function MoveHistory({ game, className = '' }: { game: GameState; className?: st
   )
 }
 
-function SeatPanel({
+export function SeatPanel({
   seat,
   game,
   visible,
@@ -406,7 +406,7 @@ function SeatPanel({
 }) {
   const hand = game.hands[seat]
   const legalActionCards = canAct ? legalCards(game, seat) : []
-  const visibleCards = canAct ? legalActionCards : hand
+  const legalActionCardIds = new Set(legalActionCards.map((card) => card.id))
   const isTurn = game.turn === seat
   const turnBadge = game.phase === 'auction' ? 'to bid' : game.phase === 'play' ? 'to play' : null
 
@@ -427,14 +427,16 @@ function SeatPanel({
       </div>
       <div className="hand" aria-label={`${seatName(seat)} hand`}>
         {visible
-          ? sortCards(visibleCards).map((card) => (
-            canAct ? (
+          ? sortCards(hand).map((card) => {
+            const legal = legalActionCardIds.has(card.id)
+            return canAct ? (
               <button
                 key={card.id}
-                className={`playing-card suit-${card.suit} legal`}
+                className={`playing-card suit-${card.suit} ${legal ? 'legal' : 'blocked'}`}
                 type="button"
+                disabled={!legal}
                 onClick={() => onPlay(seat, card)}
-                aria-label={`Play ${cardLabel(card)}`}
+                aria-label={legal ? `Play ${cardLabel(card)}` : `${cardLabel(card)} cannot be played`}
               >
                 <span>{cardLabel(card)}</span>
               </button>
@@ -447,7 +449,7 @@ function SeatPanel({
                 <span>{cardLabel(card)}</span>
               </span>
             )
-          ))
+          })
           : Array.from({ length: Math.min(hand.length, 13) }).map((_, index) => (
             <span key={index} className="card-back" aria-hidden="true" />
           ))}

--- a/web/src/styles/app.css
+++ b/web/src/styles/app.css
@@ -442,8 +442,17 @@ input:focus-visible {
   transform: translateY(-6px);
 }
 
+.playing-card.blocked {
+  border-color: rgba(90, 96, 88, 0.38);
+  background: #d7d9d3;
+  color: #5a625b;
+  filter: grayscale(0.85) contrast(0.86);
+  opacity: 0.72;
+  box-shadow: none;
+}
+
 .playing-card:disabled {
-  opacity: 0.45;
+  cursor: not-allowed;
 }
 
 .card-back {


### PR DESCRIPTION
## Summary
- keep the full visible hand rendered during card play
- disable and grey out cards that cannot legally be played
- add unit and Playwright regressions for follow-suit card visibility
- make Playwright's local port configurable with BRIDGEBOT_E2E_PORT so local tests do not reuse unrelated apps on port 3000

## Tests
- pnpm --dir web test
- pnpm --dir web typecheck
- BRIDGEBOT_E2E_PORT=3017 pnpm --dir web exec playwright test --workers=1